### PR TITLE
Fixed wrong label 03-actions.md

### DIFF
--- a/docs/pages/make/copilot-studio/03-actions.md
+++ b/docs/pages/make/copilot-studio/03-actions.md
@@ -234,7 +234,7 @@ Here follows the JSON of the adaptive card that you can use to collect the input
 }
 ```
 
-Then add a new action from the group **Add an action**, select the tab **Agent (preview)**, and select the action that you just created in [Exercise 1 - Step 3](#step-3-consuming-a-power-automate-flow).
+Then add a new action from the group **Add an action**, select the tab **Action (preview)**, and select the action that you just created in [Exercise 1 - Step 3](#step-3-consuming-a-power-automate-flow).
 Map the input arguments of the action with the variables collected by the user via the adaptive card.
 
 ![The topic designer while adding a new action from the current agent. There is the list of all the actions defined in the agent, available under the group **Add an action**.](../../../assets/images/make/copilot-studio-03/use-action-in-topic-01.png)


### PR DESCRIPTION
The current set of instructions explain to select Add an action -> Agent (preview), but it's actually Action (preview)