### PR TITLE
Docs- corrected small spelling error

### DIFF
--- a/docs/pages/extend-m365-copilot/01-declarative-copilot.md
+++ b/docs/pages/extend-m365-copilot/01-declarative-copilot.md
@@ -88,7 +88,7 @@ Go to the Teams Toolkit extension in your Visual Studio Code editor and select *
 
 ![The UI of the Teams Toolkit to start creating a new app with the 'Create a New App' button highlighted.](../../assets/images/extend-m365-copilot-01/create-new-app.png)
 
-A panel opens up where you need to select **Copilot Agent** from the list of project types.
+A panel opens up where you need to select **Declarative Agent** from the list of project types.
 
 ![The project types available when creating a new app with Teams Toolkit. Options include 'Agent', which is highlighted.](../../assets/images/extend-m365-copilot-01/copilot-extension.png)
 

--- a/docs/pages/make/agent-builder/01-first-agent.md
+++ b/docs/pages/make/agent-builder/01-first-agent.md
@@ -50,7 +50,7 @@ providing detailed instructions and advice about the best practices for home gar
 
 ![The user experience of the Copilot Studio agent builder. On the lower left side there is a textbox that you can use to provide instructions to the agent builder, while on the right side there is a preview of the agent.](../../../assets/images/make/agent-builder-01/create-agent-02.png)
 
-Once you have provided the istructions, the agent builder will ask you about the name for the new agent. Provide the name: *Gardener*. While you interact with the agent builder, on the right side of the dialog you can see there is a preview of the agent itself, including some suggested conversation starters. If the agent builder asks you about refining instructions further, provide the following sentence.
+Once you have provided the instructions, the agent builder will ask you about the name for the new agent. Provide the name: *Gardener*. While you interact with the agent builder, on the right side of the dialog you can see there is a preview of the agent itself, including some suggested conversation starters. If the agent builder asks you about refining instructions further, provide the following sentence.
 
 ```txt
 Suggest ways to keep plants and flowers shining and gorgeous


### PR DESCRIPTION
A small spelling error corrected and no longer "Copilot Agent" is available to users to select. Hence, it is corrected. 