### PR TITLE
docs(e11): clarify Exercise 3 Step 5 - Tools then Apps

### DIFF
--- a/docs/pages/extend-m365-copilot/11-mcp-app.md
+++ b/docs/pages/extend-m365-copilot/11-mcp-app.md
@@ -853,7 +853,9 @@ Building ui/status-timeline.html...
 
 <cc-end-step lab="e11" exercise="3" step="4" />
 
-### Step 5: Test the Status Timeline in MCP Inspector
+### Step 5: Test the Status Timeline Tool and Widget
+
+You will first test the raw tool response in the **Tools** section, then verify the interactive widget renders correctly in the **Apps** section.
 
 In the MCP Inspector:
 
@@ -866,7 +868,7 @@ In the MCP Inspector:
 7. **Test without a request ID**: Clear the field and click **Run Tool** 
 8. Observe the response and it will return all 3 requests with their timelines
 
-Now test the UI widget of the new tool:
+Now test the interactive UI widget in the **Apps** section:
 
 1. Navigate to the **Apps** section 
 2. Select **Refresh Apps** to refresh the list of apps


### PR DESCRIPTION
## Summary

Fixes #898

In Lab E11, Exercise 3, Step 5, the heading "Test the Status Timeline in MCP Inspector" did not signal that the step is split into two distinct parts: first testing in the **Tools** section (raw JSON response), then testing in the **Apps** section (interactive widget UI). Several users navigated straight to Apps expecting the widget, missing the Tools verification step.

## Changes

- Renamed step heading from "Test the Status Timeline in MCP Inspector" to "Test the Status Timeline Tool and Widget"
- Added an intro sentence: "You will first test the raw tool response in the **Tools** section, then verify the interactive widget renders correctly in the **Apps** section."
- Changed "Now test the UI widget of the new tool:" to "Now test the interactive UI widget in the **Apps** section:" to make the section transition explicit

## Test plan

- [x] Step 5 heading and intro clearly signal the two-part flow
- [x] No change to the actual lab steps or code
- [x] `mkdocs serve` runs cleanly