### PR TITLE
Fix Lab SCA1 scaffold details that no longer match the SPFx generator

### DIFF
--- a/docs/pages/sharepoint/sharepoint-copilot-apps/01-first-copilot-app.md
+++ b/docs/pages/sharepoint/sharepoint-copilot-apps/01-first-copilot-app.md
@@ -100,7 +100,7 @@ code .
 ```
 
 !!! note
-    Selecting **React** wires up React 17 and Fluent UI v9 as dependencies and scaffolds the component with a React entry point instead of the plain TypeScript template. This is the recommended choice for building rich UX components.
+    Selecting **React** wires up React 18 and Fluent UI v9 as dependencies and scaffolds the component with a React entry point instead of the plain TypeScript template. This is the recommended choice for building rich UX components.
 
 <cc-end-step lab="sca1" exercise="2" step="1" />
 
@@ -167,7 +167,7 @@ In this exercise you are going to explore the React component that the generator
 
 ### Step 1: Understanding the generated component
 
-Open `src/copilotComponents/helloWorld/HelloWorldCopilotComponent.tsx`. This is the component class that the Copilot host loads, and it acts as a thin host adapter. In `onInit()` it fetches the signed-in user from Microsoft Graph (`/me`) and the site title from the SharePoint REST API (`/_api/web`), both through **brokered SSO** with no token code required. In `render()` it mounts the React tree, passing down the tool `message`, the fetched data, the `hostContext`, and the host `bridge`:
+Open `src/copilotComponents/helloWorld/HelloWorldCopilotComponent.tsx`. This is the component class that the Copilot host loads, and it acts as a thin host adapter. In `onInit()` it fetches the signed-in user from Microsoft Graph (`/me`) and the site title from the SharePoint REST API (`/_api/web`), both through **brokered SSO** with no token code required. In `render()` it mounts the React tree, passing down the tool `message`, the fetched data, the `hostContext`, the host `bridge`, and two callbacks that forward display mode and resize requests to the host. The React 18 root is created once and kept on the class, so `onTeardown()` can unmount it before the host disposes of the iframe:
 
 ```tsx
   protected render(): void {
@@ -178,11 +178,21 @@ Open `src/copilotComponents/helloWorld/HelloWorldCopilotComponent.tsx`. This is 
       siteUrl: this._siteUrl,
       hostContext: this.hostContext,
       bridge: this.context.copilotBridge,
+      onRequestDisplayMode: async (mode: SPCopilotDisplayMode) => {
+        await this.requestDisplayModeAsync(mode);
+      },
+      onRequestSizeChange: async (width: number, height: number) => {
+        await this.requestSizeChangeAsync(width, height);
+      },
       targetDocument: this.context.domElement.ownerDocument,
       strings
     };
 
-    ReactDOM.render(React.createElement(HelloWorld, props), this.context.domElement);
+    if (!this._root) {
+      this._root = createRoot(this.context.domElement);
+    }
+
+    this._root.render(React.createElement(HelloWorld, props));
   }
 ```
 
@@ -265,7 +275,7 @@ First, add the new parameter to the props contract in `components/IHelloWorldPro
 Then pass it down in the `render()` method of `HelloWorldCopilotComponent.tsx`, alongside the other properties:
 
 ```tsx
-    const props: IHelloWorldLabProps = {
+    const props: IHelloWorldProps = {
       message: this.properties.message,
       accentColor: this.properties.accentColor,
       userDisplayName: this._userDisplayName,


### PR DESCRIPTION
Lab SCA1 tells you to scaffold with `yo @microsoft/sharepoint@next`. Three details in the lab describe output that tag no longer produces, checked against `@microsoft/generator-sharepoint@1.24.0-beta.3`.

**React 17 -> React 18.** The Exercise 2 note says the React template wires up React 17. The generator's `copilotComponentReact` dependency group pins `react` and `react-dom` at `18.3.1` and `@types/react` at `18.2.79`.

**The `render()` snippet in Exercise 3 is a React 17 mount.** The scaffolded component imports `createRoot` from `react-dom/client`, keeps the root on the class so `onTeardown()` can unmount it, and passes `onRequestDisplayMode` and `onRequestSizeChange` down to the React component. The snippet showed `ReactDOM.render(...)` and neither callback, so it did not match the file the reader has just been told to open. Replaced with the scaffolded code, and the sentence above it now mentions the callbacks and the root.

**`IHelloWorldLabProps` in Exercise 4 does not exist.** The generator emits `I<componentName>Props`, so with the lab's component name it is `IHelloWorldProps`. The snippet as written does not compile.

Verified by running `npm pack @microsoft/generator-sharepoint@next` and reading `lib/common/dependencies.json` and `lib/templates/copilotComponent/react/`. Docs only, one file.
