### PR TITLE
Lab E7: enable the new connection in the All vertical before testing search

### DIFF
--- a/docs/pages/extend-m365-copilot/07-add-graphconnector.md
+++ b/docs/pages/extend-m365-copilot/07-add-graphconnector.md
@@ -92,6 +92,9 @@ CONNECTOR_BASE_URL=https://localhost:3000/
 
 Now that your data is loaded into Microsoft 365 tenant, let's test if a regular search is picking up the contents in Microsoft365.com.
 
+!!! note "Include the new connection in the All vertical first"
+    A custom Copilot connector is not included in the **All** vertical until an admin enables it, so search finds nothing until you do. Go to [Verticals](https://admin.microsoft.com/Adminportal/Home#/MicrosoftSearch/verticals){target=_blank} in the Microsoft 365 admin center, select the **All** vertical, and in the **Manage connection results** panel select **Trey Feedback Connector**. See [Why aren't results displayed in Microsoft Search?](https://learn.microsoft.com/microsoft-365/copilot/connectors/frequently-asked-questions#why-aren-t-results-displayed-in-microsoft-search){target=_blank} and [Manage connector results in All vertical](https://learn.microsoft.com/microsoftsearch/connectors-in-all-vertical){target=_blank}.
+
 Go to [https://m365.cloud.microsoft/search](https://m365.cloud.microsoft/search){target=_blank} and in the search box above, type `thanks Avery`.
 
 You will see the results as below from the external connection which are basically the clients' feedback for consultant Avery Howard.


### PR DESCRIPTION
Closes #753.

Exercise 1 Step 3 sends the learner to Microsoft 365 search to confirm the connector data is indexed, but a custom Copilot connector is not included in the All vertical until an admin enables it. The search comes back empty and the lab looks broken at exactly the point where it should look like it worked. #753 reported this in December after hitting it on a real tenant.

Added a note before the search step with the admin path and the two references it rests on:

- The [Copilot connectors FAQ](https://learn.microsoft.com/microsoft-365/copilot/connectors/frequently-asked-questions#why-aren-t-results-displayed-in-microsoft-search) states that the include-results-in-All-vertical setting must be enabled for custom connectors, where prebuilt connectors have it on by default.
- [Manage connector results in All vertical](https://learn.microsoft.com/microsoftsearch/connectors-in-all-vertical) gives the control: Search & Intelligence > Customizations > Verticals > All > Manage connection results.

I left out the search vertical step that #753 also suggests. Inline results in the All vertical need no custom vertical, and a vertical created without a result type shows no results at all, so it is a longer path than this step needs. The sample connector's schema already maps the `title` semantic label, which is the other documented prerequisite for inline results.

English source only, so the Japanese page is left for the translation workflow.

Verified with `mkdocs build`: the site builds and the admonition renders on the E7 page with both links resolving.
